### PR TITLE
Update Redis VMOD

### DIFF
--- a/R1/source/vmods/vmod_redis.json
+++ b/R1/source/vmods/vmod_redis.json
@@ -1,15 +1,19 @@
 {
-    "date": "YYYY-MM-DD",
-    "desc": "Redis",
+    "date": "2016-04-18",
+    "desc": "Access to Redis / Redis Cluster servers",
     "github": {
         "branches": {
-            "3.0": "master"
+            "3.0": "3.0",
+            "4.0": "4.0",
+            "4.1": "4.1"
         },
         "project": "libvmod-redis",
-        "user": "brandonwamboldt",
+        "user": "carlosabalde",
         "vcc_path": "src/vmod_redis.vcc"
     },
     "license": "FreeBSD",
     "name": "redis",
-    "status": "mature"
+    "status": "mature",
+    "support": [ "Allenta Consulting S.L." ],
+    "maintainer": "carlos.abalde@gmail.com"
 }

--- a/R1/source/vmods/vmod_redis.json
+++ b/R1/source/vmods/vmod_redis.json
@@ -5,7 +5,8 @@
         "branches": {
             "3.0": "3.0",
             "4.0": "4.0",
-            "4.1": "4.1"
+            "4.1": "4.1",
+            "master": "master"
         },
         "project": "libvmod-redis",
         "user": "carlosabalde",


### PR DESCRIPTION
Updated info about the Redis VMOD. Previous homepage contained references to two VMODs (https://github.com/brandonwamboldt/libvmod-redis & https://github.com/carlosabalde/libvmod-redis) with the same name. The last one was removed during the migration.

I tried to keep info about both VMODs but the Python script does not allow multiple VMODs with the same name. Since the alternative VMOD has not been maintained for the last two years I think it'd be better to list this one.