### PR TITLE
Update information about vmods written by Sergey Poznyakoff

### DIFF
--- a/R1/source/vmods/vmod_basicauth.json
+++ b/R1/source/vmods/vmod_basicauth.json
@@ -1,16 +1,23 @@
 {
-    "date": "YYYY-MM-DD",
+    "name": "basicauth",
+    "date": "2017-05-10",
     "desc": "Basicauth",
     "license": "GPLv2",
-    "name": "basicauth",
+    "status": "mature",
+    "maintainer": "gray@gnu.org",
+    "support": [
+        "Norse Digital"
+    ],
+    
     "repos": "http://git.gnu.org.ua/cgit/vmod-basicauth.git",
     "rev": {
+	"4.0": {
+	    "url_vcc": "http://git.gnu.org.ua/cgit/vmod-basicauth.git/plain/src/vmod_basicauth.vcc?h=varnish-4.0",
+	    "url_doc": "http://git.gnu.org.ua/cgit/vmod-basicauth.git/plain/README?h=varnish-4.0"
+	},
         "4.1": {
-            "url_vcc": "http://git.gnu.org.ua/cgit/vmod-basicauth.git/plain/src/vmod_basicauth.vcc"
+            "url_vcc": "http://git.gnu.org.ua/cgit/vmod-basicauth.git/plain/src/vmod_basicauth.vcc",
+	    "url_doc": "http://www.gnu.org.ua/software/vmod-basicauth"
         }
-    },
-    "status": "mature",
-    "support": [
-        "NXC International"
-    ]
+    }
 }

--- a/R1/source/vmods/vmod_dbrw.json
+++ b/R1/source/vmods/vmod_dbrw.json
@@ -1,16 +1,23 @@
 {
-    "date": "YYYY-MM-DD",
+    "name": "dbrw",
+    "date": "2017-05-10",
     "desc": "Database-driven rewrites",
     "license": "GPLv2",
-    "name": "dbrw",
+    "status": "mature",
+    "maintainer": "gray@gnu.org",
+    "support": [
+        "Norse Digital"
+    ],
+    
     "repos": "http://git.gnu.org.ua/cgit/vmod-dbrw.git",
     "rev": {
+        "4.0": {
+            "url_vcc": "http://git.gnu.org.ua/cgit/vmod-dbrw.git/plain/src/vmod_dbrw.vcc?h=varnish-4.0",
+            "url_doc": "http://git.gnu.org.ua/cgit/vmod-dbrw.git/plain/README?h=varnish-4.0"
+        },
         "4.1": {
-            "url_vcc": "http://git.gnu.org.ua/cgit/vmod-dbrw.git/plain/src/vmod_dbrw.vcc"
+            "url_vcc": "http://git.gnu.org.ua/cgit/vmod-dbrw.git/plain/src/vmod_dbrw.vcc",
+            "url_doc": "http://puszcza.gnu.org.ua/software/vmod-dbrw"
         }
-    },
-    "status": "mature",
-    "support": [
-        "NXC International"
-    ]
+    }
 }

--- a/R1/source/vmods/vmod_tbf.json
+++ b/R1/source/vmods/vmod_tbf.json
@@ -1,16 +1,23 @@
 {
-    "date": "YYYY-MM-DD",
-    "desc": "tbf - Token Bucket Filtering",
-    "license": "GPLv2",
     "name": "tbf",
+    "date": "2017-05-10",
+    "desc": "Token Bucket Filtering",
+    "license": "GPLv2",
+    "status": "mature",
+    "maintainer": "gray@gnu.org",
+    "support": [
+        "Norse Digital"
+    ],
+    
     "repos": "http://git.gnu.org.ua/cgit/vmod-tbf.git",
     "rev": {
+	"4.0": {
+            "url_vcc": "http://git.gnu.org.ua/cgit/vmod-tbf.git/plain/src/vmod_tbf.vcc?h=varnish-4.0",
+            "url_doc": "http://git.gnu.org.ua/cgit/vmod-tbf.git/plain/README?h=varnish-4.0"
+        },	    
         "4.1": {
-            "url_vcc": "http://git.gnu.org.ua/cgit/vmod-tbf.git/plain/src/vmod_tbf.vcc"
+            "url_vcc": "http://git.gnu.org.ua/cgit/vmod-tbf.git/plain/src/vmod_tbf.vcc",
+            "url_doc": "http://www.gnu.org.ua/software/vmod-tbf"
         }
-    },
-    "status": "mature",
-    "support": [
-        "NXC International"
-    ]
+    }
 }

--- a/R1/source/vmods/vmod_variable.json
+++ b/R1/source/vmods/vmod_variable.json
@@ -1,16 +1,22 @@
 {
-    "date": "YYYY-MM-DD",
-    "desc": "Variable",
-    "license": "GPLv2",
     "name": "variable",
+    "date": "2017-05-10",
+    "desc": "Enhanced variable support",
+    "license": "GPLv2",
+    "status": "mature",
+    "maintainer": "gray@gnu.org",
+    "support": [
+        "Norse Digital"
+    ],
     "repos": "http://git.gnu.org.ua/cgit/vmod-variable.git/",
     "rev": {
+        "4.0": {
+            "url_vcc": "http://git.gnu.org.ua/cgit/vmod-variable.git/plain/src/variable.vcc?h=4.0",
+	    "url_doc": "http://git.gnu.org.ua/cgit/vmod-variable.git/plain/README?h=4.0"
+	},
         "4.1": {
-            "url_vcc": "http://git.gnu.org.ua/cgit/vmod-variable.git/plain/src/variable.vcc"
+            "url_vcc": "http://git.gnu.org.ua/cgit/vmod-variable.git/plain/src/variable.vcc",
+	    "url_doc": "http://www.gnu.org.ua/software/vmod-variable"
         }
-    },
-    "status": "mature",
-    "support": [
-        "NXC International"
-    ]
+    }
 }


### PR DESCRIPTION
The vmods basicauth, dbrw, tbf and variable were registered using old interface and their json files were subsequently generated automatically.  This patch updates the related information and changes the name of the supporter company (NXC International was renamed to [Norse Digital](http://norse.digital)).