### PR TITLE
Machine Images URLs on GCP have been changed. Corrected up.

### DIFF
--- a/R1/source/releases/index.rst
+++ b/R1/source/releases/index.rst
@@ -100,10 +100,10 @@ Here is a list of the current images available:
 * `Varnish Cache 4 on Red Hat Enterprise Linux 7 on GCP`_
 * `Varnish Cache 5 on Red Hat Enterprise Linux 7 on GCP`_
 
-.. _`Varnish Cache 4 on Ubuntu LTS 14.04 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-4---payg---ubuntu
-.. _`Varnish Cache 5 on Ubuntu LTS 14.04 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-5---payg---ubuntu
-.. _`Varnish Cache 4 on Red Hat Enterprise Linux 7 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-4---payg---red-hat
-.. _`Varnish Cache 5 on Red Hat Enterprise Linux 7 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-5---payg---red-hat
+.. _`Varnish Cache 4 on Ubuntu LTS 14.04 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-4-payg-ubuntu
+.. _`Varnish Cache 5 on Ubuntu LTS 14.04 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-5-payg-ubuntu
+.. _`Varnish Cache 4 on Red Hat Enterprise Linux 7 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-4-payg-red-hat
+.. _`Varnish Cache 5 on Red Hat Enterprise Linux 7 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-5-payg-red-hat
 
 
 

--- a/R1/source/releases/install_debian.rst
+++ b/R1/source/releases/install_debian.rst
@@ -87,6 +87,6 @@ Google Cloud Platform (GCP):
 * `Varnish Cache 4 on Ubuntu LTS 14.04 on GCP`_
 * `Varnish Cache 5 on Ubuntu LTS 14.04 on GCP`_
 
-.. _`Varnish Cache 4 on Ubuntu LTS 14.04 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-4---payg---ubuntu
-.. _`Varnish Cache 5 on Ubuntu LTS 14.04 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-5---payg---ubuntu
+.. _`Varnish Cache 4 on Ubuntu LTS 14.04 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-4-payg-ubuntu
+.. _`Varnish Cache 5 on Ubuntu LTS 14.04 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-5-payg-ubuntu
 

--- a/R1/source/releases/install_redhat.rst
+++ b/R1/source/releases/install_redhat.rst
@@ -87,5 +87,5 @@ Google Cloud Platform (GCP):
 * `Varnish Cache 4 on Red Hat Enterprise Linux 7 on GCP`_
 * `Varnish Cache 5 on Red Hat Enterprise Linux 7 on GCP`_
 
-.. _`Varnish Cache 4 on Red Hat Enterprise Linux 7 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-4---payg---red-hat
-.. _`Varnish Cache 5 on Red Hat Enterprise Linux 7 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-5---payg---red-hat
+.. _`Varnish Cache 4 on Red Hat Enterprise Linux 7 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-4-payg-red-hat
+.. _`Varnish Cache 5 on Red Hat Enterprise Linux 7 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-5-payg-red-hat

--- a/R1/source/releases/install_ubuntu.rst
+++ b/R1/source/releases/install_ubuntu.rst
@@ -44,7 +44,7 @@ Google Cloud Platform (GCP):
 * `Varnish Cache 4 on Ubuntu LTS 14.04 on GCP`_
 * `Varnish Cache 5 on Ubuntu LTS 14.04 on GCP`_
 
-.. _`Varnish Cache 4 on Ubuntu LTS 14.04 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-4---payg---ubuntu
-.. _`Varnish Cache 5 on Ubuntu LTS 14.04 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-5---payg---ubuntu
+.. _`Varnish Cache 4 on Ubuntu LTS 14.04 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-4-payg-ubuntu
+.. _`Varnish Cache 5 on Ubuntu LTS 14.04 on GCP`: https://console.cloud.google.com/launcher/details/varnish-public/varnish-cache-5-payg-ubuntu
 
 (this is left here to avoid linkrot)


### PR DESCRIPTION
Too many hyphens and right now Google Engineers don't like it. They claim that the new conventions would be only an alias. In reality, clearly it is not. :-/