### PR TITLE
add new Azure Marketplace URLs for Varnish Cache 4 and 5 products

### DIFF
--- a/R1/source/releases/index.rst
+++ b/R1/source/releases/index.rst
@@ -77,15 +77,11 @@ Microsoft Azure
 Varnish Cache is available on Microsoft Azure. 
 Here is a list of the current images available:
 
-* `Varnish Cache 4 on Ubuntu LTS 14.04 on Azure`_
-* `Varnish Cache 5 on Ubuntu LTS 14.04 on Azure`_
-* `Varnish Cache 4 on Red Hat Enterprise Linux 7 on Azure`_
-* `Varnish Cache 5 on Red Hat Enterprise Linux 7 on Azure`_
+* `Varnish Cache 4 and 5 on Ubuntu LTS 14.04 on Azure`_
+* `Varnish Cache 4 and 5 on Red Hat Enterprise Linux 7 on Azure`_
 
-.. _`Varnish Cache 4 on Ubuntu LTS 14.04 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache
-.. _`Varnish Cache 5 on Ubuntu LTS 14.04 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache-5-ubuntu
-.. _`Varnish Cache 4 on Red Hat Enterprise Linux 7 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache-redhat
-.. _`Varnish Cache 5 on Red Hat Enterprise Linux 7 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache-5-redhat
+.. _`Varnish Cache 4 and 5 on Ubuntu LTS 14.04 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache_
+.. _`Varnish Cache 4 and 5 on Red Hat Enterprise Linux 7 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache_
 
 Google Cloud Platform (GCP)
 ...........................

--- a/R1/source/releases/install_debian.rst
+++ b/R1/source/releases/install_debian.rst
@@ -72,11 +72,9 @@ Microsoft Azure
 Here is a list of the currently available images for Ubuntu LTS on 
 Microsoft's Azure cloud:
 
-* `Varnish Cache 4 on Ubuntu LTS 14.04 on Azure`_
-* `Varnish Cache 5 on Ubuntu LTS 14.04 on Azure`_
+* `Varnish Cache 4 and 5 on Ubuntu LTS 14.04 on Azure`_
 
-.. _`Varnish Cache 4 on Ubuntu LTS 14.04 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache
-.. _`Varnish Cache 5 on Ubuntu LTS 14.04 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache-5-ubuntu
+.. _`Varnish Cache 4 and 5 on Ubuntu LTS 14.04 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache_
 
 Google Cloud Platform (GCP)
 ...........................

--- a/R1/source/releases/install_redhat.rst
+++ b/R1/source/releases/install_redhat.rst
@@ -71,11 +71,9 @@ Microsoft Azure
 Here is a list of the currently available images for RHEL7 on 
 Microsoft's Azure cloud:
 
-* `Varnish Cache 4 on Red Hat Enterprise Linux 7 on Azure`_
-* `Varnish Cache 5 on Red Hat Enterprise Linux 7 on Azure`_
+* `Varnish Cache 4 and 5 on Red Hat Enterprise Linux 7 on Azure`_
 
-.. _`Varnish Cache 4 on Red Hat Enterprise Linux 7 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache-redhat
-.. _`Varnish Cache 5 on Red Hat Enterprise Linux 7 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache-5-redhat
+.. _`Varnish Cache 4 and 5 on Red Hat Enterprise Linux 7 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache_
 
 
 Google Cloud Platform (GCP)

--- a/R1/source/releases/install_ubuntu.rst
+++ b/R1/source/releases/install_ubuntu.rst
@@ -29,11 +29,9 @@ Microsoft Azure
 Here is a list of the currently available images for Ubuntu LTS on 
 Microsoft's Azure cloud:
 
-* `Varnish Cache 4 on Ubuntu LTS 14.04 on Azure`_
-* `Varnish Cache 5 on Ubuntu LTS 14.04 on Azure`_
+* `Varnish Cache 4 and 5 on Ubuntu LTS 14.04 on Azure`_
 
-.. _`Varnish Cache 4 on Ubuntu LTS 14.04 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache
-.. _`Varnish Cache 5 on Ubuntu LTS 14.04 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache-5-ubuntu
+.. _`Varnish Cache 4 and 5 on Ubuntu LTS 14.04 on Azure`: https://azuremarketplace.microsoft.com/en-us/marketplace/apps/varnish.varnish-cache_
 
 Google Cloud Platform (GCP)
 ...........................


### PR DESCRIPTION
We did grouping on Microsoft Azure Marketplace. Currently, version 4 or 5 can be selected on the same Varnish Cache product page. The URLs clearly has been changed so update is needed.