### PR TITLE
Add release file for 6.0.2, news, and update installation instructions

### DIFF
--- a/R1/source/index.rst
+++ b/R1/source/index.rst
@@ -8,6 +8,41 @@ Varnish HTTP Cache
 What is happening
 -----------------
 
+2018-11-12 - Varnish 6.0.2 released, official Long Time Support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We are happy to announce the release of :ref:`rel6.0.2`.
+
+This release is recommended for everyone running 6.0, and it contains
+many bug fixes and some new features.
+
+At the same time we bring you the news that that 6.0 will maintained
+much longer than other Varnish Cache Releases, and that new
+repositories, Varnish 6.0 LTS, are introduced.
+
+If you are currently using official packages, you need to change to
+the new LTS repositories to get 6.0.2. Please follow the instructions
+on the release page to set up the new repository for your platform.
+
+The packaging of this release differs slightly from previous Varnish
+versons. This is described in the
+`upgrading notes <docs/6.0/whats-new/upgrading-6.0.html#packaging-changes>`_
+for 6.0. These changes were originally intended for the initial 6.0
+release, but unfortunately they did not make it into the 6.0.0 or
+6.0.1 packages.
+
+At some point the previous LTS, Varnish 4.1, will reach its End of
+Life. It was first released in September 2015, and now is the time
+for users to start upgrading to Varnish 6.0 LTS.
+
+If you are still using Varnish 4.1, you should be able to migrate to
+6.0 without touching your VCL.  In our experience so far, upgrading is
+very straightforward.
+
+Read more about `upgrading <docs/6.1/whats-new/upgrading-6.0.html>`_
+and `what's new </docs/6.0/whats-new/changes-6.0.html>`_ in Varnish
+Cache 6.0.
+
 2018-10-26 - Bug fix release: Varnish 6.1.1
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/R1/source/releases/install_debian.rst
+++ b/R1/source/releases/install_debian.rst
@@ -27,7 +27,11 @@ using the manual installation procedures.
 Instructions for installing the official repository which contains the newest 
 Varnish Cache 6 release are available at:
 
-* https://packagecloud.io/varnishcache/varnish60/install#manual-deb
+* https://packagecloud.io/varnishcache/varnish60lts/install#manual-deb
+
+With the release of 6.0.2, users have to switch to switch repositories to get
+the latest version. Read more about this on :ref:`rel6.0.2`.
+
 
 Official packages of 4.1
 ------------------------

--- a/R1/source/releases/install_redhat.rst
+++ b/R1/source/releases/install_redhat.rst
@@ -20,7 +20,11 @@ using the manual installation procedures.
 Instructions for installing the official repository which contains the newest 
 Varnish Cache 6 release are available at:
 
-* https://packagecloud.io/varnishcache/varnish60/install#manual-rpm
+* https://packagecloud.io/varnishcache/varnish60lts/install#manual-rpm
+
+With the release of 6.0.2, users have to switch to switch repositories to get
+the latest version. Read more about this on :ref:`rel6.0.2`.
+
 
 Official packages of 4.1
 ------------------------

--- a/R1/source/releases/rel6.0.2.rst
+++ b/R1/source/releases/rel6.0.2.rst
@@ -1,0 +1,34 @@
+.. _rel6.0.2:
+
+Varnish Cache 6.0.2
+===================
+
+* Source download :download:`varnish-6.0.2.tgz <varnish-6.0.2.tgz>`
+
+* The packaging of this release differs slightly from previous Varnish versons. This is described in the `upgrading notes <docs/6.0/whats-new/upgrading-6.0.html#packaging-changes>`_ for 6.0. These changes were originally intended for the initial 6.0 release, but unfortunately they did not make it into the 6.0.0 or 6.0.1 packages.
+
+* 2018-11-07 /Pål Hermunn Johansen
+
+
+
+More information:
+
+* `List of changes and other good reasons to update to 6.0 </docs/6.0/whats-new/changes-6.0.html>`_
+
+* `Upgrading </docs/6.0/whats-new/upgrading-6.0.html>`_
+
+
+Operating System Specific Installation Guides
+---------------------------------------------
+
+* :ref:`install_ubuntu`
+* :ref:`install_debian`
+* :ref:`install_redhat`
+* :ref:`install_freebsd`
+
+EL7, Debian-Stretch and Ubuntu-Xenial
+packages can be found on
+`PackageCloud.io <https://packagecloud.io/varnishcache/varnish60lts>`_
+
+We recommend using the manual installation procedure available at:
+https://packagecloud.io/varnishcache/varnish60lts/install#manual


### PR DESCRIPTION
This "release 6.0.2" commit is big because we also announce Long Time
Support of the 6.0 branch, a new set of repositories and explain that
the packaging changes intended for 6.0.0 is not included before now.