### PR TITLE
Fix install instructions for FreeBSD

### DIFF
--- a/R1/source/faq/find.rst
+++ b/R1/source/faq/find.rst
@@ -8,11 +8,11 @@ Install on FreeBSD
 
 This should work::
 
-  pkg install varnish
+  pkg install varnish6
 
 or::
 
-  cd /usr/ports/www/varnish
+  cd /usr/ports/www/varnish6
   make all install clean
 
 Where is the bug I opened in 2012?


### PR DESCRIPTION
Package [varnish](https://www.freshports.org/www/varnish) was removed, only [varnish4](https://www.freshports.org/www/varnish4) or [varnish6](https://www.freshports.org/www/varnish6) exist.