### PR TITLE
Fix install instructions for FreeBSD

### DIFF
--- a/R1/source/releases/install_freebsd.rst
+++ b/R1/source/releases/install_freebsd.rst
@@ -3,13 +3,13 @@
 Installation on FreeBSD
 =======================
 
-Varnish is distributed in the FreeBSD ports collection as 'www/varnish5'.
+Varnish is distributed in the FreeBSD ports collection as 'www/varnish6'.
 
 You can either install it as binary package::
 
-	pkg install varnish5
+	pkg install varnish6
 
 Or build it from source::
 
-	cd /usr/ports/www/varnish5
+	cd /usr/ports/www/varnish6
 	make all install clean


### PR DESCRIPTION
Packages [varnish](https://www.freshports.org/www/varnish) and [varnish5](https://www.freshports.org/www/varnish5) were removed, only [varnish4](https://www.freshports.org/www/varnish4) or [varnish6](https://www.freshports.org/www/varnish6) exist.