### PR TITLE
Simplify non GitHub vmods

### DIFF
--- a/R1/source/vmods/build.py
+++ b/R1/source/vmods/build.py
@@ -25,12 +25,15 @@ class vmod(object):
 		return self.j["name"]
 
 	def repos(self):
-		i = self.j.get("repos")
-		if i != None:
-			return i
 		g = self.j.get("github")
 		if g != None:
-			return "https://github.com/" + g["user"] + "/" + g["project"]
+			return {"Github": "https://github.com/" + g["user"] + "/" + g["project"]}
+		i = self.j.get("repos")
+		if isinstance(i, dict):
+			return i
+		if i != None:
+			return {"Repos": i}
+		return None
 
 	def versions(self):
 		r = self.j.get("rev")
@@ -91,10 +94,10 @@ class vmod(object):
 		l.append(self.j.get("status"))
 
 		s = ""
-		if "github" in self.j:
-			s += " `Github <%s>`__ " % self.repos()
-		elif "repos" in self.j:
-			s += " `Repos <%s>`__ " % self.repos()
+		i = self.repos()
+		if i != None:
+			for n in sorted(i.iterkeys()):
+				s += " `%s <%s>`__ " % (n, i[n])
 		l.append(s)
 
 		s = ""

--- a/R1/source/vmods/build.py
+++ b/R1/source/vmods/build.py
@@ -76,7 +76,7 @@ class vmod(object):
 			if "url_doc" in r[rev]:
 				return r[rev]["url_doc"]
 			fmt = self.j.get("fmt")
-			if fmt != None and "url_vcc" in fmt:
+			if fmt != None and "url_doc" in fmt:
 				fmt = fmt["url_doc"]
 			else:
 				fmt = None

--- a/R1/source/vmods/build.py
+++ b/R1/source/vmods/build.py
@@ -51,7 +51,15 @@ class vmod(object):
 	def url_vcc(self, rev):
 		r = self.j.get("rev")
 		if r != None:
-			return r[rev]["url_vcc"]
+			if "url_vcc" in r[rev]:
+				return r[rev]["url_vcc"]
+			fmt = self.j.get("fmt")
+			if fmt != None and "url_vcc" in fmt:
+				fmt = fmt["url_vcc"]
+			else:
+				fmt = None
+			if fmt != None and "branch" in r[rev]:
+				return fmt % r[rev]["branch"]
 		g = self.j.get("github")
 		if g != None:
 			s = "https://raw.githubusercontent.com/"
@@ -64,8 +72,16 @@ class vmod(object):
 
 	def url_doc(self, rev):
 		r = self.j.get("rev")
-		if r != None and "url_doc" in r[rev]:
-			return r[rev]["url_doc"]
+		if r != None:
+			if "url_doc" in r[rev]:
+				return r[rev]["url_doc"]
+			fmt = self.j.get("fmt")
+			if fmt != None and "url_vcc" in fmt:
+				fmt = fmt["url_doc"]
+			else:
+				fmt = None
+			if fmt != None and "branch" in r[rev]:
+				return fmt % r[rev]["branch"]
 		g = self.j.get("github")
 		if g != None and "doc_path" in g:
 			s = "https://github.com/"

--- a/R1/source/vmods/vmod_weightadjust.json
+++ b/R1/source/vmods/vmod_weightadjust.json
@@ -8,35 +8,18 @@
         "UPLEX": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust",
         "gitlab": "https://gitlab.com/uplex/varnish/libvmod-weightadjust"
     },
+    "fmt": {
+        "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/%s/src/vmod_weightadjust.vcc",
+        "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/%s/README.rst"
+    },
     "rev": {
-        "4.1": {
-            "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/4.1/src/vmod_weightadjust.vcc",
-            "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/4.1/README.rst"
-        },
-        "5.1": {
-            "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/5.1/src/vmod_weightadjust.vcc",
-            "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/5.1/README.rst"
-        },
-        "5.2": {
-            "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/5.2/src/vmod_weightadjust.vcc",
-            "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/5.2/README.rst"
-        },
-        "6.0": {
-            "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/6.0/src/vmod_weightadjust.vcc",
-            "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/6.0/README.rst"
-        },
-        "6.1": {
-            "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/6.1/src/vmod_weightadjust.vcc",
-            "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/6.1/README.rst"
-        },
-        "6.2": {
-            "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/6.2/src/vmod_weightadjust.vcc",
-            "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/6.2/README.rst"
-        },
-        "master": {
-            "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/master/src/vmod_weightadjust.vcc",
-            "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/master/README.rst"
-        }
+        "4.1": { "branch": "4.1" },
+        "5.1": { "branch": "5.1" },
+        "5.2": { "branch": "5.2" },
+        "6.0": { "branch": "6.0" },
+        "6.1": { "branch": "6.1" },
+        "6.2": { "branch": "6.1" },
+        "master": { "branch": "master" }
     },
     "status": "mature",
     "support": [

--- a/R1/source/vmods/vmod_weightadjust.json
+++ b/R1/source/vmods/vmod_weightadjust.json
@@ -1,10 +1,13 @@
 {
-    "date": "2017-10-05",
+    "date": "2019-03-26",
     "desc": "random director with dynamically adjustable weights",
     "license": "FreeBSD",
     "maintainer": "varnish-support@uplex.de",
     "name": "weightadjust",
-    "repos": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust",
+    "repos": {
+        "UPLEX": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust",
+        "gitlab": "https://gitlab.com/uplex/varnish/libvmod-weightadjust"
+    },
     "rev": {
         "4.1": {
             "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/4.1/src/vmod_weightadjust.vcc",
@@ -15,8 +18,20 @@
             "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/5.1/README.rst"
         },
         "5.2": {
-            "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/master/src/vmod_weightadjust.vcc",
-            "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/master/README.rst"
+            "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/5.2/src/vmod_weightadjust.vcc",
+            "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/5.2/README.rst"
+        },
+        "6.0": {
+            "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/6.0/src/vmod_weightadjust.vcc",
+            "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/6.0/README.rst"
+        },
+        "6.1": {
+            "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/6.1/src/vmod_weightadjust.vcc",
+            "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/6.1/README.rst"
+        },
+        "6.2": {
+            "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/6.2/src/vmod_weightadjust.vcc",
+            "url_doc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/blob/6.2/README.rst"
         },
         "master": {
             "url_vcc": "https://code.uplex.de/uplex-varnish/libvmod-weightadjust/raw/master/src/vmod_weightadjust.vcc",


### PR DESCRIPTION
These commits add
* the option to specify multiple repos for a vmod (as a json object with the attribute being the name of the repo and the value being the url)
* the option to facilitate url_vcc and url_doc speficifcation for non-github repos

both are illustated with one vmod json file