### PR TITLE
Correct Cookie doc link

### DIFF
--- a/R1/source/vmods/vmod_cookie.json
+++ b/R1/source/vmods/vmod_cookie.json
@@ -5,7 +5,7 @@
         "branches": {
             "4.1": "master"
         },
-        "doc_path": "docs/cookie.rst",
+        "doc_path": "docs/vmod_cookie.rst",
         "project": "varnish-modules",
         "user": "varnish",
         "vcc_path": "src/vmod_cookie.vcc"


### PR DESCRIPTION
The existing link points to [docs/cookie.rst](https://github.com/varnish/varnish-modules/blob/master/docs/cookie.rst) and the working link is [docs/vmod_cookie.rst](https://github.com/varnish/varnish-modules/blob/master/docs/vmod_cookie.rst).