### PR TITLE
Update libvmod-queryfilter with 6.x support

### DIFF
--- a/R1/source/vmods/vmod_queryfilter.json
+++ b/R1/source/vmods/vmod_queryfilter.json
@@ -1,12 +1,13 @@
 {
-    "date": "2018-01-14",
+    "date": "2020-03-02",
     "desc": "Simple query string filter/sort module",
     "github": {
         "branches": {
             "3.0": "master",
             "4.0": "master",
             "4.1": "master",
-            "5.2": "master"
+            "5.2": "master",
+            "6.2": "master"
         },
         "project": "libvmod-queryfilter",
         "user": "NYTimes",


### PR DESCRIPTION
[libvmod-queryfilter](https://github.com/nytimes/libvmod-queryfilter/blob/master/README.md) is now officially compatible with Varnish 6, as of release 1.0.0.

_Thanks!_