### PR TITLE
Fix typo: Each major release is supported for one year

### DIFF
--- a/R1/source/releases/index.rst
+++ b/R1/source/releases/index.rst
@@ -9,7 +9,7 @@ Varnish Cache is released every 6 months.
 Release                Date         EOL Date         Download
 ====================== ============ ===============  ===========
 :ref:`rel6.6.1`        2021-07-13   2022-03-15       :download:`varnish-6.6.1.tgz <varnish-6.6.1.tgz>`
-:ref:`rel6.5.2`        2021-07-13   2022-09-15       :download:`varnish-6.5.2.tgz <varnish-6.5.2.tgz>`
+:ref:`rel6.5.2`        2021-07-13   2021-09-15       :download:`varnish-6.5.2.tgz <varnish-6.5.2.tgz>`
 :ref:`rel6.0.8`        2021-07-13   Supported        :download:`varnish-6.0.8.tgz <varnish-6.0.8.tgz>`
 ====================== ============ ===============  ===========
 


### PR DESCRIPTION
Other text is indicating one year, but the table was wrong.