### PR TITLE
Update navigation.html

### DIFF
--- a/R1/source/_templates/navigation.html
+++ b/R1/source/_templates/navigation.html
@@ -29,7 +29,7 @@
         | <a href="http://book.varnish-software.com/3.0/">3.0</a>
     </li>
     <li class="toctree-l1">
-	<a href="https://www.varnish-software.com/wiki">Varnish (Web Dev) Wiki</a>
+	<a href="https://www.varnish-software.com/developers/">Varnish Developer Portal</a>
     </li>
     <li class="toctree-l1">
 	<a href="https://github.com/varnishcache/varnish-cache">Github project</a>


### PR DESCRIPTION
The Varnish Wiki is no longer something we like to promote: the content is heavily outdated and the layout is far from user-friendly.

Our latest effort is the Varnish Developer Portal (https://www.varnish-software.com/developers/) which I'm spearheading. This should replace the Wiki and by the end of November the Wiki should be gone.

The content of the Wiki will be migrated and all Wiki pages will be redirected to their corresponding page on the Varnish Developer Portal.

Thanks for updating this.
Thijs