### PR TITLE
queryfilter: latest release date updated + varnish 6.3+ / 7.x support…

### DIFF
--- a/R1/source/vmods/vmod_queryfilter.json
+++ b/R1/source/vmods/vmod_queryfilter.json
@@ -1,5 +1,5 @@
 {
-    "date": "2020-03-02",
+    "date": "2023-01-09",
     "desc": "Simple query string filter/sort module",
     "github": {
         "branches": {
@@ -7,7 +7,9 @@
             "4.0": "master",
             "4.1": "master",
             "5.2": "master",
-            "6.2": "master"
+            "6.2": "master",
+            "6.3": "main",
+            "7.2.1": "main"
         },
         "doc_path": "README.md",
         "project": "libvmod-queryfilter",


### PR DESCRIPTION
Latest release of vmod-queryfilter:
 - [bug-fixes](https://github.com/nytimes/libvmod-queryfilter/issues/6)
 - Varnish 6.3+ support
 - Varnish 7 support