### PR TITLE
Generic authorship and Copyright

### DIFF
--- a/R1/source/conf.py
+++ b/R1/source/conf.py
@@ -47,8 +47,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Varnish Cache Project'
-copyright = u'2016-2023, Poul-Henning Kamp'
-author = u'Poul-Henning Kamp'
+copyright = u'2016-2024, The Varnish Cache Contributors'
+author = u'The Varnish Cache Contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
as of today, each page on https://varnish-cache.org/ redendered from the sphinx source contains the line

	©2016-2023, Poul-Henning Kamp

While this is true for much of the content, it is not for all of it and because we, several people from UPLEX, intend to contribute significant amounts of documentation in the near future, we would like to change this into something more generic, without the need to state specific copyright and authorship on each page.

This is a suggestion only and we are open to alternative proposals. And at any rate, no-one intends to lessen phk's contribution.