### PR TITLE
Enable sphinx-design enxtension

### DIFF
--- a/R1/source/conf.py
+++ b/R1/source/conf.py
@@ -29,7 +29,7 @@ import shlex
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ["sphinx_design"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
I Like to enable sphinx-design (package available via pip) to allow some more modern design elements. The PR it self doesn't do much, there should be little to no visible impact, but i'd like to have it merged as base for further work starting with a switch to furo-theme.

A good idea where it would get us can be found at the sphinx-design dokumentation:
https://sphinx-design.readthedocs.io/en/furo-theme/